### PR TITLE
[FIX] 재발급/블랙리스트 정책 수정_(NEW: 재발급 시 엑세스 토큰 불필요, 그에 따른 블랙리스트 로직 수정)

### DIFF
--- a/src/main/java/com/sampoom/auth/api/auth/controller/AuthController.java
+++ b/src/main/java/com/sampoom/auth/api/auth/controller/AuthController.java
@@ -115,35 +115,12 @@ public class AuthController {
             }
         }
 
-    // 엑세스 토큰 추출
-        String accessToken = null;
-        // WEB: 쿠키에서
-        if ("WEB".equalsIgnoreCase(clientType)) {
-            if (request.getCookies() != null) {
-                // 두 쿠키 중에
-                for (Cookie cookie : request.getCookies()) {
-                    // 엑세스 토큰 쿠키인 것 추출
-                    if ("ACCESS_TOKEN".equals(cookie.getName())) {
-                        accessToken = cookie.getValue();
-                        break;
-                    }
-                }
-            }
-        }
-        // APP: 헤더에서
-        else if ("APP".equalsIgnoreCase(clientType)) {
-                String header = request.getHeader("Authorization");
-                if (header != null && header.startsWith("Bearer ")) {
-                    accessToken= header.substring(7);
-                }
-        }
-
         // 토큰 유효성 검증
-        if (refreshToken == null || refreshToken.isBlank() || accessToken == null || accessToken.isBlank()) {
+        if (refreshToken == null || refreshToken.isBlank()) {
             throw new UnauthorizedException(ErrorStatus.TOKEN_INVALID);
         }
 
-        RefreshResponse resp = authService.refresh(refreshToken, accessToken);
+        RefreshResponse resp = authService.refresh(refreshToken);
 
         if ("WEB".equalsIgnoreCase(clientType)) {
             addAuthCookies(response,resp.getAccessToken(),resp.getRefreshToken(), accessTtlSeconds, refreshTtlSeconds);


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close # SPM-285

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 이제 재발급 시 더이상 엑세스토큰을 필요로 하지 않습니다.
-- 기존에 WEB은 만료 시 자동 삭제되는 쿠키 정책에 따라, 엑세스토큰이 사라져 재발급 불가능으로 인한 수정
- 그에 따라 기존 재발급 시 블랙리스트 로직 인자 중 하나인 엑세스토큰을 리프레시토큰의 JTI로 변경했습니다.
-- 엑세스토큰과 리프레스토큰의 JTI가 동일한 점을 이용

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 만료된 토큰을 자동으로 정리하는 스케줄된 정리 기능 추가
  * 토큰 검증을 위한 새로운 확인 메커니즘 추가

* **버그 수정**
  * 토큰 새로고침 흐름 간소화로 인증 성능 개선
  * 토큰 관리 로직 정확성 향상

* **리팩토링**
  * 토큰 관리 및 검증 메커니즘 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->